### PR TITLE
Fix .spec for ns7. Refs NethServer/dev#5000

### DIFF
--- a/nethserver-sogo.spec
+++ b/nethserver-sogo.spec
@@ -31,9 +31,9 @@ NethServer SOGo configuration
 perl createlinks
 
 %install
-rm -rf $RPM_BUILD_ROOT
-(cd root; find . -depth -print | cpio -dump $RPM_BUILD_ROOT)
-%{genfilelist} $RPM_BUILD_ROOT > %{name}-%{version}-filelist
+rm -rf %{buildroot}
+(cd root; find . -depth -print | cpio -dump %{buildroot})
+%{genfilelist} %{buildroot} > %{name}-%{version}-filelist
 echo "%doc COPYING" >> %{name}-%{version}-filelist
 
 %post
@@ -42,6 +42,7 @@ echo "%doc COPYING" >> %{name}-%{version}-filelist
 
 %files -f %{name}-%{version}-filelist
 %defattr(-,root,root)
+%dir %{_nseventsdir}/%{name}-update
 
 %changelog
 * Mon Oct 05 2015 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.5.5-1


### PR DESCRIPTION
note: 
- sogo packages in NS 7 repository are too old to install this package, you need to move sogo\* and sope49\* packages from NS 6.7 repo
- nethserver-mysql-update failed, more investigations needed
  read(7, "Enter current password for root "..., 8192) = 50
  read(7, "\n", 8192)                     = 1
  sendto(5, "<142>Dec 28 17:09:55 esmith::eve"..., 94, MSG_NOSIGNAL, NULL, 0) = 94
  read(7, "ERROR 2002 (HY000): Can't connec"..., 8192) = 103
  sendto(5, "<142>Dec 28 17:09:55 esmith::eve"..., 146, MSG_NOSIGNAL, NULL, 0) = 146
