### PR TITLE
#5024 SOGo junkmail folder

### DIFF
--- a/root/etc/e-smith/templates/sogo-config/05general_preferences
+++ b/root/etc/e-smith/templates/sogo-config/05general_preferences
@@ -18,6 +18,7 @@
     $S{SOGoDraftsFolderName} = ($sogod{'DraftsFolder'} || "Drafts");
     $S{SOGoSentFolderName} = ($sogod{'SentFolder'} || "Sent");
     $S{SOGoTrashFolderName} = ($sogod{'TrashFolder'} || "Trash");
+    $S{SOGoJunkFolderName} = ($dovecot{SpamFolder} || "Junk");
 
     $S{SOGoIMAPServer} = 'localhost';
     $S{SOGoMailDomain} = $DomainName || 'localdomain';


### PR DESCRIPTION
Sets `SOGoJunkFolderName` to (if present) dovecot's configuration-db `SpamFolder` value

SOGo default Spam-mail folder is `Junk` which, since v3, is displayed in the sogo web-UI.
