### PR TITLE
Proper syntax multiple SOGoUserSources dictionaires #5028

### DIFF
--- a/root/etc/e-smith/templates/etc/sogo/sogo.conf/42user_source_active_directory
+++ b/root/etc/e-smith/templates/etc/sogo/sogo.conf/42user_source_active_directory
@@ -51,9 +51,7 @@
         scope = SUB;
         displayName = "$adsRealm users";
         isAddressBook = YES;
-     \}
-    );
-    SOGoUserSources =(
+     \},
      \{
         id = AD_Groups;
         type = ldap;
@@ -69,9 +67,7 @@
         scope = SUB;
         displayName = "$adsRealm groups";
         isAddressBook = YES;
-     \}
-    );
-    SOGoUserSources =(
+     \},
      \{
         id = AD_DistributionLists;
         type = ldap;

--- a/root/etc/e-smith/templates/etc/sogo/sogo.conf/46user_source_ldap
+++ b/root/etc/e-smith/templates/etc/sogo/sogo.conf/46user_source_ldap
@@ -33,9 +33,7 @@
         displayName = "{$SystemName} groups";
         hostname = "ldapi://";
         isAddressBook = NO;
-     \}
-    );
-    SOGoUserSources =(
+     \},
      \{   
         id = users;
         type = ldap;

--- a/root/etc/e-smith/templates/etc/sogo/sogo.conf/60general
+++ b/root/etc/e-smith/templates/etc/sogo/sogo.conf/60general
@@ -4,10 +4,9 @@
     SOGoSuperUsernames = ({$sogod{'AdminUsers'} || 'admin'}); // This is an array - keep the parens!
     SOGoMemcachedHost = "127.0.0.1";
     SxVMemLimit = {$sogod{'SxVMemLimit'} || '384'};
-   /* Form Nethesis GNUStep configuration */
-    WOMessageUseUTF8 = YES;
-    WOParsersUseUTF8 = YES;
-    WOUseRelativeURLs = YES;
     SOGoEnablePublicAccess = YES;
-    NGUseUTF8AsURLEncoding = YES;
-    SOGoAppointmentSendEMailReceipts = YES;
+
+  /* From Nethesis GNUStep configuration
+     Undocumented in sogo instalation manual, could be deprecated */
+    // NGUseUTF8AsURLEncoding = YES;
+    // SOGoAppointmentSendEMailReceipts = YES;


### PR DESCRIPTION
Concluding groups where found as sending a mail to them worked was incorrect,
mail was send to person entry in ldap.

This is the right syntax , if `isAddressBook` of the group entry is set to `YES`;
groups show up in adresses sogo webinterface

Removed settings proven to be deprecated:
http://marc.info/?l=sogo-users&m=139347468822741&w=2

Marked out undocumented (probably deprecated) settings
