### PR TITLE
Redirect from root (/) to /SOGo if SOGo lives in a exclusive virtual …

### DIFF
--- a/root/etc/e-smith/templates/etc/httpd/conf.d/SOGo.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/SOGo.conf/10base
@@ -41,7 +41,7 @@
 
 <VirtualHost *:443>
  ServerName $sogo_host
- 
+ RedirectMatch ^/\$ /SOGo
  SSLEngine on
  SSLCertificateFile "/etc/pki/tls/certs/$sogo_cert.crt"
  SSLCertificateKeyFile "/etc/pki/tls/private/$sogo_cert.key"


### PR DESCRIPTION
…host

If the sogod VirtualHost prop is set we might as well redirect, the /SOGo part is not mandatory in the request url.