### PR TITLE
Dis-/Enable card- calldav in sogo.conf

### DIFF
--- a/root/etc/e-smith/templates/etc/sogo/sogo.conf/75dav
+++ b/root/etc/e-smith/templates/etc/sogo/sogo.conf/75dav
@@ -1,0 +1,8 @@
+{
+     my $dav = ($sogod{'Dav'} || "enabled") eq "enabled" ? "YES" : "NO";
+     $OUT .= qq(
+  /* 75 enable cal- and carddav */
+    SOGoAddressBookDAVAccessEnabled = $dav;
+    SOGoCalendarDAVAccessEnabled = $dav;
+);
+}

--- a/root/etc/e-smith/templates/etc/sogo/sogo.conf/75dav
+++ b/root/etc/e-smith/templates/etc/sogo/sogo.conf/75dav
@@ -1,6 +1,6 @@
 {
-     my $dav = ($sogod{'Dav'} || "enabled") eq "enabled" ? "YES" : "NO";
-     $OUT .= qq(
+    my $dav = (($sogod{'Dav'} || "enabled") eq "enabled") ? "YES" : "NO";
+    $OUT .= qq(
   /* 75 enable cal- and carddav */
     SOGoAddressBookDAVAccessEnabled = $dav;
     SOGoCalendarDAVAccessEnabled = $dav;

--- a/root/etc/e-smith/templates/etc/sogo/sogo.conf/75dav
+++ b/root/etc/e-smith/templates/etc/sogo/sogo.conf/75dav
@@ -1,5 +1,5 @@
 {
-    my $dav = (($sogod{'Dav'} || "enabled") eq "enabled") ? "YES" : "NO";
+    my $dav = (($sogod{'Dav'} || "disabled") eq "enabled") ? "YES" : "NO";
     $OUT .= qq(
   /* 75 enable cal- and carddav */
     SOGoAddressBookDAVAccessEnabled = $dav;


### PR DESCRIPTION
https://github.com/orgs/NethServer/projects/2#card-11103641

AS-IS the rewrite rule is removed;
prevent  (card,cal} dav staying available at https://FQDN/SOGo/dav