### PR TITLE
Remove deprecated Samba-events

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -104,23 +104,14 @@ event_actions('pre-backup-data', qw(
     nethserver-sogo-backup-users 80
 ));
 
-
 #
-# nethserver-samba-* events
+# nethserver-sssd-save event
 #
-foreach (qw(
-   nethserver-samba-save
-   nethserver-samba-update
-   nethserver-sssd-save
-)) {
-
-    event_services($_, qw(
-        sogod restart
-        memcached restart
-    ));
-
-    event_templates($_, qw(
+event_templates('nethserver-sssd-save',qw(
       /etc/sogo/sogo.conf
 ));
 
-}
+event_services('nethserver-sssd-save', qw(
+        sogod restart
+        memcached restart
+));


### PR DESCRIPTION
NethServer/dev#5579
and
https://github.com/orgs/NethServer/projects/2#card-11100521

The hooks in to Samba events seems to be NS6 legacy code which can be cleaned up.

I can not find any dependency with the nethserver-samba file server

Pro: sogod does not restart unneeded at samba events
Con: it's in there for years doing no harm, so keep is as it is.

**EDIT:**

As an memory fresh-up it is introduced for Active Directory integration in NS6
http://dev.nethserver.org/issues/2000