### PR TITLE
Automatic translation build for build travis

### DIFF
--- a/.transifex.sh
+++ b/.transifex.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#
+# push the string automaticaly to transifex once the PR has been merged
+# https://docs.transifex.com/transifex-github-integrations/github-tx-client#integrating-the-client-with-travis-ci
+
+if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+  echo "We are not on the master branch. We push translation only on master"
+  # analyze current branch and react accordingly
+  exit 0
+fi
+
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+  echo "We are on a pull request. We push translation only after the PR merge"
+  # analyze current state PR merged or PR and react accordingly
+  exit 0
+fi
+
+
+pip install virtualenv
+virtualenv ~/env
+source ~/env/bin/activate
+pip install transifex-client
+echo $'[https://www.transifex.com]\nhostname = https://www.transifex.com\nusername = '"api"$'\npassword = '"$TRANSIFEX_API_TOKEN"$'\n' > ~/.transifexrc
+tx push -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,6 @@ script: >
     -e AUTOBUILD_SECRET
     -e AUTOBUILD_SECRET_URL
     nethserver/build uploadrpms-travis
+
+after_success:
+  - ./.transifex.sh

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -18,7 +18,8 @@
         "WOWorkersCount":"Number of workers (one per activesync client connected)",
         "SOGoInternalSyncInterval":"maximum time in second before to checks after changes",
         "settings_updated_ok": "The settings have been well updated",
-        "settings_updated_error": "The settings have not well updated"
+        "settings_updated_error": "The settings have not well updated",
+        "translation_test_do_not_translate":"It is a test for the automatic build translation 25 01 2022 15:22"
     },
     "about": {
         "title": "About",


### PR DESCRIPTION
Make a travis configuration to push the translation to transifex.

We must have a ENV VAR in the travis configuration `TRANSIFEX_API_TOKEN` with a token value from transifex

We test if the branch is master and if the state is a PR merged, we do not push to transifex if it is still a PR.

I saw that ENV vars must be encrypte inside travis, what do you think ?

Obviously this commit must be cherrypicked to any relevant repository


EDIT : see the gist file of the transifex client https://gist.github.com/stephdl/3d6b10d3061765106286e46c960bf458

https://github.com/NethServer/dev/issues/6629
